### PR TITLE
Prevent OpenSea Listing

### DIFF
--- a/contracts/extensions/approve/HumanboundApproveLogic.sol
+++ b/contracts/extensions/approve/HumanboundApproveLogic.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13;
+
+import "@violetprotocol/erc721extendable/contracts/extensions/base/approve/ApproveLogic.sol";
+import { HumanboundPermissionState, HumanboundPermissionStorage } from "../../storage/HumanboundPermissionStorage.sol";
+
+contract HumanboundApproveLogic is ApproveLogic {
+    function approve(address to, uint256 tokenId) public pure override {
+        revert("HumanboundApproveLogic: approvals disallowed");
+    }
+
+    function setApprovalForAll(address operator, bool approved) public pure override {
+        revert("HumanboundApproveLogic: approvals disallowed");
+    }
+}

--- a/test/approve/Approve.ts
+++ b/test/approve/Approve.ts
@@ -1,0 +1,41 @@
+import { artifacts, waffle } from "hardhat";
+import type { Artifact } from "hardhat/types";
+
+import type {
+  AccessTokenVerifier,
+  EATVerifierConnector,
+  HumanboundExtendLogic,
+  HumanboundMintLogic,
+} from "../../src/types";
+import { shouldBehaveLikeHumanboundBurn } from "./Approve.behavior";
+
+describe("Humanbound Burn Extension", function () {
+  before(async function () {
+    const extendArtifact: Artifact = await artifacts.readArtifact("HumanboundExtendLogic");
+    this.extend = <HumanboundExtendLogic>await waffle.deployContract(this.signers.admin, extendArtifact, []);
+
+    const verifierArtifact: Artifact = await artifacts.readArtifact("AccessTokenVerifier");
+    this.verifier = <AccessTokenVerifier>(
+      await waffle.deployContract(this.signers.admin, verifierArtifact, [this.signers.admin.address])
+    );
+    await this.verifier.rotateIntermediate(this.signers.admin.address);
+    await this.verifier.rotateIssuer(this.signers.admin.address);
+
+    const EATVerifierConnectorArtifact: Artifact = await artifacts.readArtifact("EATVerifierConnector");
+    this.verifierExtension = <EATVerifierConnector>(
+      await waffle.deployContract(this.signers.admin, EATVerifierConnectorArtifact)
+    );
+
+    const mintArtifact: Artifact = await artifacts.readArtifact("HumanboundMintLogic");
+    this.mintLogic = <HumanboundMintLogic>await waffle.deployContract(this.signers.admin, mintArtifact);
+
+    this.domain = {
+      name: "Ethereum Access Token",
+      version: "1",
+      chainId: await this.signers.admin.getChainId(),
+      verifyingContract: this.verifier.address,
+    };
+  });
+
+  shouldBehaveLikeHumanboundBurn();
+});

--- a/test/mint/Mint.behavior.ts
+++ b/test/mint/Mint.behavior.ts
@@ -104,7 +104,7 @@ export function shouldBehaveLikeHumanboundMint(): void {
             beforeEach("construct ethereum access token", async function () {
               this.params = [this.signers.user0.address, tokenId];
               this.value = {
-                expiry: BigNumber.from(Math.floor(new Date().getTime() / 1000) + 200),
+                expiry: BigNumber.from(Math.floor(new Date().getTime() / 1000) + 2000),
                 functionCall: {
                   functionSignature: extendableAsMint.interface.getSighash("mint"),
                   target: extendableAsMint.address.toLowerCase(),
@@ -178,7 +178,7 @@ export function shouldBehaveLikeHumanboundMint(): void {
             beforeEach("construct ethereum access token", async function () {
               this.params = [this.signers.user0.address, tokenId];
               this.value = {
-                expiry: BigNumber.from(Math.floor(new Date().getTime() / 1000) + 200),
+                expiry: BigNumber.from(Math.floor(new Date().getTime() / 1000) + 2000),
                 functionCall: {
                   functionSignature: extendableAsMint.interface.getSighash("mint"),
                   target: extendableAsMint.address.toLowerCase(),


### PR DESCRIPTION
Added HumanboundApproveLogic which blocks calls to the `approve` and `setApprovalForAll` functions to disallow people from listing humanbound tokens on OpenSea.